### PR TITLE
Update distros in tests

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -3,7 +3,7 @@ name: Molecule Test
 on:
   push:
     tags:
-      - '*'
+      - "*"
     branches:
       - main
   pull_request:
@@ -18,9 +18,11 @@ jobs:
       COLLECTION_NAME: graphing
 
     strategy:
-      max-parallel: 4
       matrix:
-        distro: [centos7, rockylinux8, debian11, ubuntu2004]
+        distro:
+          - rockylinux9
+          - ubuntu2204
+          - debian12
         scenario: [default]
 
     steps:
@@ -30,7 +32,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: "3.x"
 
       - name: Install dependencies
         run: |
@@ -49,5 +51,5 @@ jobs:
           molecule --debug test -s ${{ matrix.scenario }}
         env:
           MOLECULE_DISTRO: ${{ matrix.distro }}
-          PY_COLORS: '1'
-          ANSIBLE_FORCE_COLOR: '1'
+          PY_COLORS: "1"
+          ANSIBLE_FORCE_COLOR: "1"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,14 @@ Ansible collection to provide a graphing backend for Icinga and other systems
 
 [![CI](https://github.com/NETWAYS/ansible-collection-graphing/workflows/Molecule%20Test/badge.svg?event=push)](https://github.com/NETWAYS/ansible-collection-graphing/workflows/Molecule%20Test/badge.svg)
 
+This role is tested with:
+
+* Rockylinux 9
+* Rockylinux 10
+* Ubuntu 22.04
+* Ubuntu 24.04
+* Debian 12
+
 ## Roles ##
 
 ### InfluxDB ###

--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ Ansible collection to provide a graphing backend for Icinga and other systems
 This role is tested with:
 
 * Rockylinux 9
-* Rockylinux 10
 * Ubuntu 22.04
-* Ubuntu 24.04
 * Debian 12
 
 ## Roles ##

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -5,16 +5,17 @@ driver:
   name: docker
 platforms:
   - name: graphing-default
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-rockylinux9}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
+    cgroupns_mode: host
 provisioner:
   name: ansible
+  config_options:
+    defaults:
+      roles_path: "$MOLECULE_PROJECT_DIRECTORY/.."
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint roles/

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
 ansible
 ansible-lint
 molecule
-molecule-docker
+molecule-plugins[docker]

--- a/roles/influxdb/tasks/debian.yml
+++ b/roles/influxdb/tasks/debian.yml
@@ -1,7 +1,14 @@
 ---
+- name: Ensure gpg exists, for signing keys
+  ansible.builtin.apt:
+    name:
+      - gpg
+      - gpg-agent
+    state: present
+
 - name: Ensure InfluxDB key is available (Debian)
   apt_key:
-    url: https://repos.influxdata.com/influxdb.key
+    url: https://repos.influxdata.com/influxdata-archive.key
     state: present
 
 - name: Ensure InfluxDB apt repository is configured (Debian)

--- a/roles/influxdb/tasks/redhat.yml
+++ b/roles/influxdb/tasks/redhat.yml
@@ -1,7 +1,12 @@
 ---
+- name: Ensure gpg exists, for signing keys
+  ansible.builtin.package:
+    name: gnupg
+    state: present
+
 - name: Ensure InfluxDB repository key is available (RedHat)
   rpm_key:
-    key: https://repos.influxdata.com/influxdb.key
+    key: https://repos.influxdata.com/influxdata-archive.key
     state: present
 
 - name: Ensure InfluxDB yum repository is configured (RedHat)
@@ -11,4 +16,4 @@
     file: influxdb
     baseurl: https://repos.influxdata.com/rhel/$releasever/$basearch/stable
     gpgcheck: yes
-    gpgkey: https://repos.influxdata.com/influxdb.key
+    gpgkey: https://repos.influxdata.com/influxdata-archive.key


### PR DESCRIPTION
Remove outdated distros and add latest distros for workflows.
There are no packages for RHEL 10 or Ubuntu 24 (yet?).